### PR TITLE
[study] webRTC

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,9 +1,10 @@
 import { createBrowserRouter } from 'react-router-dom';
+import WebRTCComponent from './WebRTC';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <></>,
+    element: <WebRTCComponent />,
   },
 ]);
 

--- a/src/WebRTC/index.tsx
+++ b/src/WebRTC/index.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const WebRTCComponent: React.FC = () => {
+  const localVideoRef = useRef<HTMLVideoElement>(null);
+  const remoteVideoRef = useRef<HTMLVideoElement>(null);
+  const peerConnection = useRef<RTCPeerConnection | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const [isCameraOn, setIsCameraOn] = useState(true);
+
+  useEffect(() => {
+    const startLocalStream = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        localStreamRef.current = stream;
+        if (localVideoRef.current && remoteVideoRef.current) {
+          localVideoRef.current.srcObject = stream;
+        }
+      } catch (error) {
+        console.error('접근 권환을 허용해주세요', error);
+      }
+    };
+
+    startLocalStream();
+
+    const createPeerConnection = () => {
+      peerConnection.current = new RTCPeerConnection();
+
+      if (localStreamRef.current) {
+        localStreamRef.current.getTracks().forEach((track) => {
+          peerConnection.current?.addTrack(track, localStreamRef.current!);
+        });
+      }
+
+      peerConnection.current.ontrack = (event) => {
+        const [stream] = event.streams;
+        if (remoteVideoRef.current) {
+          remoteVideoRef.current.srcObject = stream;
+        }
+      };
+    };
+
+    createPeerConnection();
+
+    return () => {
+      localStreamRef.current?.getTracks().forEach((track) => track.stop());
+      peerConnection.current?.close();
+    };
+  }, []);
+
+  const toggleCamera = () => {
+    if (localStreamRef.current) {
+      localStreamRef.current.getVideoTracks().forEach((track) => {
+        track.enabled = !track.enabled;
+      });
+      setIsCameraOn((prev) => !prev);
+    }
+  };
+
+  return (
+    <div>
+      <h1 style={{ fontSize: '30px' }}>WebRTC 프리태스크</h1>
+      <video
+        ref={localVideoRef}
+        autoPlay
+        playsInline
+        muted
+        style={{ width: '250px', height: '200px' }}
+      />
+      <video
+        ref={remoteVideoRef}
+        autoPlay
+        playsInline
+        style={{ width: '250px', height: '200px', backgroundColor: '#ccc' }}
+      />
+      <button onClick={toggleCamera}>{isCameraOn ? '카메라 켜기' : '카메라 끄기'}</button>
+    </div>
+  );
+};
+
+export default WebRTCComponent;


### PR DESCRIPTION
### WebRTC란?
Web-RealTime-Communication 의 약자로 서버의 개입이나 플러그인 없이 브라우저간 통신을 할 수 있게 하는 기술
- 브라우저간 통신을 위한 각 브라우저 외에 별도의 서버 필요

### 소스코드
- `getUserMedia`로 브라우저에서 vidio와 audio 권한을 받아 stream에 저장
- 로컬 비디오 ref에 stream 할당 
- `peerConnection`으로 두 사용자 연결 (상대방의 stream 정보 받아오기)
```tsx
import React, { useEffect, useRef, useState } from 'react';

const WebRTCComponent: React.FC = () => {
  const localVideoRef = useRef<HTMLVideoElement>(null);
  const remoteVideoRef = useRef<HTMLVideoElement>(null);
  const peerConnection = useRef<RTCPeerConnection | null>(null);
  const localStreamRef = useRef<MediaStream | null>(null);
  const [isCameraOn, setIsCameraOn] = useState(true);

  useEffect(() => {
    const startLocalStream = async () => {
      try {
        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
        localStreamRef.current = stream;
        if (localVideoRef.current && remoteVideoRef.current) {
          localVideoRef.current.srcObject = stream;
        }
      } catch (error) {
        console.error('접근 권환을 허용해주세요', error);
      }
    };

    startLocalStream();

    const createPeerConnection = () => {
      peerConnection.current = new RTCPeerConnection();

      if (localStreamRef.current) {
        localStreamRef.current.getTracks().forEach((track) => {
          peerConnection.current?.addTrack(track, localStreamRef.current!);
        });
      }

      peerConnection.current.ontrack = (event) => {
        const [stream] = event.streams;
        if (remoteVideoRef.current) {
          remoteVideoRef.current.srcObject = stream;
        }
      };
    };

    createPeerConnection();

    return () => {
      localStreamRef.current?.getTracks().forEach((track) => track.stop());
      peerConnection.current?.close();
    };
  }, []);

  const toggleCamera = () => {
    if (localStreamRef.current) {
      localStreamRef.current.getVideoTracks().forEach((track) => {
        track.enabled = !track.enabled;
      });
      setIsCameraOn((prev) => !prev);
    }
  };

  return (
    <div>
      <h1 style={{ fontSize: '30px' }}>WebRTC 프리태스크</h1>
      <video
        ref={localVideoRef}
        autoPlay
        playsInline
        muted
        style={{ width: '250px', height: '200px' }}
      />
      <video
        ref={remoteVideoRef}
        autoPlay
        playsInline
        style={{ width: '250px', height: '200px', backgroundColor: '#ccc' }}
      />
      <button onClick={toggleCamera}>{isCameraOn ? '카메라 켜기' : '카메라 끄기'}</button>
    </div>
  );
};

export default WebRTCComponent;
```

### 결과 영상
https://github.com/user-attachments/assets/8a47f4e9-00d7-47c5-9e5c-ae9478acf260

### 추가로 해야하는 것
- 웹소켓을 사용해 실시간으로 중개되는 서버 구현하기
